### PR TITLE
feat!: support multi conditions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,17 @@ function walk(node: Node, callbacks: { [key: string]: Function }) {
   return node;
 }
 
+function buildConditions(expression: string, rawValue: string): string {
+  const sep = '||';
+  const values = rawValue.split(sep);
+  const conditions = [];
+
+  for (const value of values) {
+    conditions.push(`${expression} === ${value}`);
+  }
+  return conditions.join(` ${sep} `);
+}
+
 function getInjectionValue(
   type: string,
   expression: string,
@@ -32,9 +43,9 @@ function getInjectionValue(
   const comment = `<!-- Injected by svelte-switch-case -->`;
   switch (type) {
     case '_open_':
-      return `${comment}\n{#if ${expression} === ${value}}`;
+      return `${comment}\n{#if ${buildConditions(expression, value)}}`;
     case 'case':
-      return `{:else if ${expression} === ${value}}`;
+      return `{:else if ${buildConditions(expression, value)}}`;
     case 'default':
       return `{:else}`;
     case '_close_':

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -61,6 +61,40 @@ describe('Svelte switch case preprocessor', () => {
     runTest(code, expectedOutput);
   });
 
+  it('should support multi conditions', () => {
+    const code = `
+      <script>
+        let animal = 'dog';
+      </script>
+
+      <section>
+        Can fly ?
+        {#switch animal}
+          {:case "cat" || "dog"}
+            <p>No</p>
+          {:case "bird"}
+            <p>Yes</p>
+        {/switch}
+      </section>
+    `;
+    const expectedOutput = `
+      <script>
+        let animal = 'dog';
+      </script>
+
+      <section>
+        Can fly ?
+        <!-- Injected by svelte-switch-case -->
+        {#if animal === "cat" || animal === "dog"}
+          <p>No</p>
+        {:else if animal === "bird"}
+          <p>Yes</p>
+        {/if}
+      </section>
+    `;
+    runTest(code, expectedOutput);
+  });
+
   it('should handle nested switch blocks', () => {
     const code = `
     <script>


### PR DESCRIPTION
This PR implements inline support of multi conditions using the following syntax:
```html
<script>
  let animal = 'dog';
</script>

<section>
  Can fly ?
  {#switch animal}
    {:case "cat" || "dog"}
      <p>No</p>
    {:case "bird"}
      <p>Yes</p>
  {/switch}
</section>
```

Closes #1 