### PR TITLE
Migrate to Svelte v4

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 import { parse } from 'svelte-parse';
-import {
+import MagicString, { SourceMap } from 'magic-string';
+
+import { validateSyntax } from './validate';
+import pkg from '../package.json';
+
+import type {
   Injection,
   Node,
   Position,
@@ -7,8 +12,6 @@ import {
   PreprocessorOptions,
   PreprocessorOutput,
 } from './types';
-import { validateSyntax } from './validate';
-import MagicString, { SourceMap } from 'magic-string';
 
 function walk(node: Node, callbacks: { [key: string]: Function }) {
   const children = node.children || node.branches;
@@ -169,7 +172,7 @@ function processMarkup({
 
 export default function preprocess(): Preprocessor {
   return {
-    name: 'svelte-switch-case',
+    name: pkg.name,
     markup: processMarkup,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {
   Injection,
   Node,
   Position,
+  Preprocessor,
   PreprocessorOptions,
   PreprocessorOutput,
 } from './types';
@@ -166,8 +167,9 @@ function processMarkup({
   return { code: output.toString(), map };
 }
 
-export default function preprocess(): { markup: Function } {
+export default function preprocess(): Preprocessor {
   return {
+    name: 'svelte-switch-case',
     markup: processMarkup,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,10 @@
 import { SourceMap } from 'magic-string';
 
+export interface Preprocessor {
+  name: string;
+  markup: (options: PreprocessorOptions) => PreprocessorOutput;
+}
+
 export interface Node {
   type: string;
   name: string;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import switchCase from '../src';
 
+import pkg from '../package.json';
+
 const { markup: processMarkup } = switchCase();
 
 function minify(strings) {
@@ -13,20 +15,29 @@ function minify(strings) {
     .trim();
 }
 
-function runTest(code, expectedOutput) {
+function runTest(code: string, expectedOutput: string) {
   code = minify(code);
   expectedOutput = minify(expectedOutput);
 
-  const { code: output } = processMarkup({ content: code });
+  const { code: output } = processMarkup({
+    filename: 'test.svelte',
+    content: code,
+  });
   expect(minify(output)).toBe(expectedOutput);
 }
 
-function runThrowingTest(code) {
-  const t = () => processMarkup({ content: code });
+function runThrowingTest(code: string) {
+  const t = () => processMarkup({ filename: 'test.svelte', content: code });
   expect(t).toThrow(SyntaxError);
 }
 
 describe('Svelte switch case preprocessor', () => {
+  it('preprocessor should have a name', () => {
+    const preprocessor = switchCase();
+
+    expect(preprocessor.name).toBe(pkg.name);
+  });
+
   it('should transpile a simple switch', () => {
     const code = `
     <script>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "skipLibCheck": true,
     "types": ["jest", "node"],
     "outDir": "dist",
-    "noEmit": true
+    "noEmit": true,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules/**/*", "dist", "examples"]


### PR DESCRIPTION
This PR migrates the package to be compatible with [version 4](https://svelte.dev/blog/svelte-4) of Svelte.